### PR TITLE
Include unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## "Made-With"
->Generating cool taglines for all the millenials out there. 
+>Generating cool taglines for all the millenials out there.
 
 _Made-With_ is a for-fun command-line tool. Globally install _Made-With_ and generare your next footer. No longer will `Made with Javascript and <3` dominate the footers of the internet.
 
-**Install**
+### Install
 
 `npm install made-with -g`
 
@@ -13,3 +13,16 @@ _Made-With_ is a for-fun command-line tool. Globally install _Made-With_ and gen
 
 ![](https://cloud.githubusercontent.com/assets/12987958/13902542/85e34662-ee22-11e5-8c3c-b49b27973d64.png)
 
+**Install in an application:**
+
+`npm install --save made-with`
+
+
+**Require and generate phrase:**
+
+```
+madeWith = require('made-with')
+
+console.log(madeWith.generatePhrase());
+// => "Made with HTML5 and ice cream.""
+```

--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ madeWith = require('made-with')
 console.log(madeWith.generatePhrase());
 // => "Made with HTML5 and ice cream.""
 ```
+
+### Development
+
+**Setup:**
+
+`npm install`
+
+This will install `mocha`, `chalk`, and any other dependencies local to this project.
+
+**Testing:**
+To run the tests in `./tests` directory, simply run `npm run test`.

--- a/index.js
+++ b/index.js
@@ -52,4 +52,6 @@ function generatePhrase() {
 
 console.log(generatePhrase())
 
+exports.util = util;
+exports.phrase = phrase;
 exports.generatePhrase = generatePhrase;

--- a/index.js
+++ b/index.js
@@ -10,23 +10,29 @@ var util = {
     return Math.floor(Math.random() * arr.length);
   },
 
-  getRandomItem: function (arr, ignoreItem) {
-    var arrCopy = arr.slice();
+  getItem: function (arr, index, ignoreItem) {
+    var arrCopy = arr.slice(),
+        selection = arrCopy[index];
 
-    if (ignoreItem) arrCopy.splice(arrCopy.indexOf(ignoreItem), 1)
-
-    return arrCopy[this.getRandomIndex(arrCopy)];
+    if (selection === ignoreItem) {
+      arrCopy.splice(arrCopy.indexOf(ignoreItem), 1);
+      return arrCopy[index];
+    }
+    return selection;
   }
 }
 
 var phrase = {
   choose: function (ignorePhrase) {
-    return util.getRandomItem(phrases, ignorePhrase);
+    var index = util.getRandomIndex(phrases);
+    return util.getItem(phrases, index);
   },
 
   build: function (first, second) {
-    var firstStyle = util.getRandomItem(chalkStyles);
-    var secondStyle = util.getRandomItem(chalkStyles, firstStyle);
+    var firstIndex = util.getRandomIndex(chalkStyles),
+        secondIndex = util.getRandomIndex(chalkStyles),
+        firstStyle = util.getItem(chalkStyles, firstIndex),
+        secondStyle = util.getItem(chalkStyles, secondIndex, firstStyle);
 
     return 'Made with ' + chalk[firstStyle](first) + ' and ' + chalk[secondStyle](second) + '.';
   },
@@ -42,3 +48,5 @@ var finalPhrase = phrase.build(phraseOne, phraseTwo);
 var formattedPhrase = phrase.format(finalPhrase);
 
 console.log(formattedPhrase);
+
+module.exports = formattedPhrase

--- a/index.js
+++ b/index.js
@@ -42,11 +42,14 @@ var phrase = {
   }
 }
 
-var phraseOne = phrase.choose();
-var phraseTwo = phrase.choose(phraseOne);
-var finalPhrase = phrase.build(phraseOne, phraseTwo);
-var formattedPhrase = phrase.format(finalPhrase);
+function generatePhrase() {
+  var phraseOne = phrase.choose(),
+   phraseTwo = phrase.choose(phraseOne),
+   finalPhrase = phrase.build(phraseOne, phraseTwo);
 
-console.log(formattedPhrase);
+  return phrase.format(finalPhrase);
+}
 
-module.exports = formattedPhrase
+console.log(generatePhrase())
+
+exports.generatePhrase = generatePhrase;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/mocha"
   },
   "bin": {
     "made-with": "./index.js"

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^1.1.1"
+  },
+  "devDependencies": {
+    "mocha": "^2.4.5"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,12 @@
+var assert = require('assert');
+var util = require('../index').util
+
+var phrases = ['A', 'B', 'C', 'D'];
+
+describe('Util', function() {
+  describe('#getItem()', function () {
+    it('should return a single string', function () {
+      assert.equal('A', util.getItem(phrases, 0));
+    });
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -8,5 +8,8 @@ describe('Util', function() {
     it('should return a single string', function () {
       assert.equal('A', util.getItem(phrases, 0));
     });
+    it('should not return the ignoreItem argument', function () {
+      assert.equal('B', util.getItem(phrases, 0, 'A'));
+    });
   });
 });


### PR DESCRIPTION
This is a really neat project! Nice work. 

I'd like to include Mocha unit tests. This first commit makes `getItem` more predictable / testable by pulling the randomization out of the function body. Here, it now uses the randomly generated number as an argument. This way we can test `getItem` without worrying about the randomly generated output.

Here are the unit test cases I'm going to write in the next commit. Let me know if you'd like to add more or discuss any of these. :)

Tests:

* `getItem` returns a specific string from the array argument, based on the index passed in.
* `getItem` will ignore any strings provided as the `ignoreItem` parameter.